### PR TITLE
Fix Astropy-related performance issue with GCRS object comparison

### DIFF
--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -585,11 +585,15 @@ class SpacecraftHistory:
 
         """
 
-        if np.all(d1 == d2):
-            return d1
+        # NB: do NOT compare GCRS objects d1 and d2 directly for
+        # Astropy performance reasons -- convert them to vectors
+        # first!
 
         v1 = d1.cartesian.xyz
         v2 = d2.cartesian.xyz
+
+        if np.all(v1 == v2):
+            return d1
 
         # angle between v1, v2
         norm = d1.spherical.distance * d2.spherical.distance


### PR DESCRIPTION
SpacecraftHistory._interp_location() interpolates two locations specified as Astropy GCRS objects. The function first checks whether these objects are the same to avoid having to do the interpolation math.  Unfortunately, comparing two GCRS objects in Astropy is extraordinarily expensive, which led to a serious performance issue with unbinned analysis observed by Pascal.

This patch moves the equality check after the GCRS objects are converted to 3-vectors, which fixes the issue.