### PR TITLE
Line background estimation

### DIFF
--- a/cosipy/background_estimation/LineBackgroundEstimation.py
+++ b/cosipy/background_estimation/LineBackgroundEstimation.py
@@ -2,12 +2,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 from histpy import Histogram, Axis, Axes
+import healpy as hp
 import astropy.units as u
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.optimize import curve_fit
 from scipy import integrate
 from iminuit import Minuit
+from itertools import product
 
 class LineBackgroundEstimation:
     """
@@ -262,22 +264,160 @@ class LineBackgroundEstimation:
         weight = integrate.quad(lambda x: self.bkg_spectrum_model(x, *self.bkg_spectrum_model_parameter), *integrate_energy_range)[0]
         return weight, energy_indices
 
-    def generate_bkg_model_histogram(self, source_energy_range, bkg_estimation_energy_ranges):
+    def _apply_spatial_filter(self, bkg_model, new_axes, smoothing_fwhm=None, l_cut=None):
         """
-        Generate a background model histogram based on the fitted model.
-
+        Apply spatial filter (smoothing or l_cut) to the last axis of bkg_model.
+    
         Parameters
         ----------
+        bkg_model : np.ndarray
+            Background model array. The last axis is the HEALPix spatial axis.
+        new_axes : Axes
+            Axes object containing PsiChi axis with nside information.
+        smoothing_fwhm : :py:class:`astropy.units.quantity.Quantity`, optional
+            Full width at half maximum for Gaussian smoothing.
+        l_cut : int, optional
+            Maximum multipole moment to retain.
+    
+        Returns
+        -------
+        np.ndarray
+            Filtered background model array.
+        """
+        if smoothing_fwhm is not None:
+            for idx in product(*[range(s) for s in bkg_model.shape[:-1]]):
+                bkg_model[idx] = hp.smoothing(bkg_model[idx], fwhm=smoothing_fwhm.to('rad').value)
+    
+        if l_cut is not None:
+            logger.info(f"Applying low-pass filter with l_cut={l_cut}: retaining features on angular scales larger than ~{180.0 / l_cut:.1f} degrees.")
+
+            lmax = new_axes['PsiChi'].nside * 4
+            ell, _ = hp.Alm.getlm(lmax)
+
+            for idx in product(*[range(s) for s in bkg_model.shape[:-1]]):
+                alm = hp.map2alm(bkg_model[idx], lmax=lmax)
+                alm[ell > l_cut] = 0.0
+                bkg_model[idx] = hp.alm2map(alm, nside=new_axes['PsiChi'].nside)
+
+            # clip negative values introduced by the low-pass filter
+            bkg_model = np.clip(bkg_model, 0.0, None)
+    
+        return bkg_model
+    
+    def _rebin_phi(self, bkg_model, rebin_phi):
+        """
+        Rebin the second-to-last axis (Phi) by summing over rebin_phi bins.
+    
+        Parameters
+        ----------
+        bkg_model : np.ndarray
+            Background model array.
+        rebin_phi : int
+            Number of bins to merge.
+    
+        Returns
+        -------
+        rebinned : np.ndarray
+            Rebinned array.
+        n_groups : int
+            Number of groups after rebinning.
+        phi_axis_idx : int
+            Index of the Phi axis.
+        """
+        phi_axis_idx = len(bkg_model.shape) - 2
+        n_phi = bkg_model.shape[phi_axis_idx]
+        n_groups = n_phi // rebin_phi
+    
+        rebinned_shape = list(bkg_model.shape)
+        rebinned_shape[phi_axis_idx] = n_groups
+        rebinned = np.zeros(rebinned_shape)
+    
+        for g in range(n_groups):
+            sl = [slice(None)] * len(bkg_model.shape)
+            sl[phi_axis_idx] = slice(g * rebin_phi, (g + 1) * rebin_phi)
+            rebinned_sl = [slice(None)] * len(rebinned.shape)
+            rebinned_sl[phi_axis_idx] = g
+            rebinned[tuple(rebinned_sl)] = np.sum(bkg_model[tuple(sl)], axis=phi_axis_idx)
+    
+        return rebinned, n_groups, phi_axis_idx
+    
+    def _unbin_phi(self, bkg_model, rebinned, n_groups, rebin_phi, phi_axis_idx):
+        """
+        Restore the rebinned Phi axis back to the original binning.
+    
+        The spatial pattern of each Phi bin is replaced by the filtered template,
+        normalized so that the total count of each original Phi bin is preserved.
+    
+        Parameters
+        ----------
+        bkg_model : np.ndarray
+            Original background model array (before rebinning).
+        rebinned : np.ndarray
+            Filtered rebinned array (template).
+        n_groups : int
+            Number of groups after rebinning.
+        rebin_phi : int
+            Number of bins per group.
+        phi_axis_idx : int
+            Index of the Phi axis.
+    
+        Returns
+        -------
+        np.ndarray
+            Background model restored to original binning.
+        """
+        for g in range(n_groups):
+            rebinned_sl = [slice(None)] * len(rebinned.shape)
+            rebinned_sl[phi_axis_idx] = g
+    
+            # normalize template over spatial axis -> spatial pattern only
+            # shape: same as one Phi slice of bkg_model
+            template = rebinned[tuple(rebinned_sl)]
+            template_sum = np.sum(template)
+            template_normalized = np.where(template_sum > 0, template / template_sum, 0.0)
+    
+            # apply to each original Phi bin, preserving its total count
+            for i in range(rebin_phi):
+                sl_i = [slice(None)] * len(bkg_model.shape)
+                sl_i[phi_axis_idx] = g * rebin_phi + i
+    
+                factor_i = np.sum(bkg_model[tuple(sl_i)])  # scalar: total count of this Phi bin
+                bkg_model[tuple(sl_i)] = template_normalized * factor_i
+    
+        return bkg_model
+    
+    def generate_bkg_model_histogram(self, source_energy_range, bkg_estimation_energy_ranges,
+                                      smoothing_fwhm=None, l_cut=None, rebin_phi=None):
+        """
+        Generate a background model histogram based on the fitted model.
+    
+        Parameters
+        ----------
+        source_energy_range : tuple
+            Energy range for background model.
         bkg_estimation_energy_ranges : list of tuple
             List of energy ranges for background estimation.
-        smoothing_fwhm : float, optional
-            Full width at half maximum for smoothing, by default None.
-
+        smoothing_fwhm : :py:class:`astropy.units.quantity.Quantity`, optional
+            Full width at half maximum for Gaussian smoothing, by default None.
+        l_cut : int, optional
+            Maximum multipole moment to retain. Features on angular scales larger
+            than approximately 180/l_cut degrees will be preserved. Default is None.
+        rebin_phi : int, optional
+            Number of Phi bins to merge before applying the spatial filter.
+            After filtering, the original binning is restored: the spatial pattern
+            of each Phi bin is replaced by the filtered template, normalized to
+            preserve the original total count of each Phi bin. Default is None.
+    
         Returns
         -------
         Histogram
             The generated background model histogram.
         """
+        # validate options
+        if smoothing_fwhm is not None and l_cut is not None:
+            logger.error("smoothing_fwhm and l_cut cannot be specified at the same time.")
+            raise ValueError("smoothing_fwhm and l_cut cannot be specified at the same time.")
+    
         # intergrated spectrum in the background estimation energy ranges
         weights = []
         energy_indices_list = []
@@ -285,31 +425,44 @@ class LineBackgroundEstimation:
             weight, energy_indices = self._get_weight_indices(bkg_estimation_energy_range)
             weights.append(weight)
             energy_indices_list.append(energy_indices)
-            
+    
         # intergrated spectrum in the source region
-        source_weight = integrate.quad(lambda x: self.bkg_spectrum_model(x, *self.bkg_spectrum_model_parameter), *source_energy_range.value)[0]
-
+        source_weight = integrate.quad(
+            lambda x: self.bkg_spectrum_model(x, *self.bkg_spectrum_model_parameter),
+            *source_energy_range.value
+        )[0]
+    
         # prepare a new histogram
         new_axes = []
         for axis in self.event_histogram.axes:
             if axis.label != "Em":
                 new_axes.append(axis)
             else:
-                new_axes.append(Axis(source_energy_range, label = "Em"))
+                new_axes.append(Axis(source_energy_range, label="Em"))
         new_axes = Axes(new_axes, copy_axes=False)
-        
         bkg_model = np.zeros(new_axes.shape)
-
+    
         # fill contents
         for energy_indices in energy_indices_list:
             for energy_index in energy_indices:
                 if new_axes[0].label != "Em":
-                    bkg_model += self.event_histogram[:,energy_index].todense()
+                    bkg_model += self.event_histogram[:, energy_index].todense()
                 else:
                     bkg_model += self.event_histogram[energy_index].todense()
-
+    
         # normalization
         corr_factor = source_weight / np.sum(weights)
         bkg_model *= corr_factor
-
+    
+        # apply spatial filter (with or without phi rebinning)
+        if smoothing_fwhm is not None or l_cut is not None:
+            if rebin_phi is not None:
+                # rebin Phi axis → filter → restore original binning
+                rebinned, n_groups, phi_axis_idx = self._rebin_phi(bkg_model, rebin_phi)
+                rebinned = self._apply_spatial_filter(rebinned, new_axes, smoothing_fwhm, l_cut)
+                bkg_model = self._unbin_phi(bkg_model, rebinned, n_groups, rebin_phi, phi_axis_idx)
+            else:
+                # filter directly without rebinning
+                bkg_model = self._apply_spatial_filter(bkg_model, new_axes, smoothing_fwhm, l_cut)
+    
         return Histogram(new_axes, contents=bkg_model, copy_contents=False)

--- a/tests/background_estimation/test_line_background_estimation.py
+++ b/tests/background_estimation/test_line_background_estimation.py
@@ -74,3 +74,50 @@ def test_line_background_estimation():
     background_region_2 = (3500.0, 6310.0) * u.keV #background counts estimation before the line
 
     bkg_model_histogram = instance.generate_bkg_model_histogram(source_range, [background_region_1, background_region_2])
+
+    ## Case 5: smoothing
+    bkg_model_histogram_smoothing = instance.generate_bkg_model_histogram(
+        source_range, [background_region_1, background_region_2],
+        smoothing_fwhm=20 * u.deg)
+
+    ### total counts should be preserved after smoothing
+    assert np.isclose(np.sum(bkg_model_histogram_smoothing), np.sum(bkg_model_histogram), rtol=1e-3)
+
+    ## Case 6: l_cut
+    bkg_model_histogram_l_cut = instance.generate_bkg_model_histogram(
+        source_range, [background_region_1, background_region_2],
+        l_cut=3)
+
+    ### shape should be unchanged after l_cut filtering
+    assert bkg_model_histogram_l_cut.shape == bkg_model_histogram.shape
+
+    ## Case 7: smoothing_fwhm and l_cut cannot be specified at the same time
+    with pytest.raises(ValueError):
+        instance.generate_bkg_model_histogram(
+            source_range, [background_region_1, background_region_2],
+            smoothing_fwhm=20 * u.deg, l_cut=3)
+
+    ## Case 8: rebin_phi + smoothing
+    bkg_model_histogram_rebin_smoothing = instance.generate_bkg_model_histogram(
+        source_range, [background_region_1, background_region_2],
+        smoothing_fwhm=20 * u.deg, rebin_phi=5)
+
+    ### shape should be unchanged after rebin+unbin
+    assert bkg_model_histogram_rebin_smoothing.shape == bkg_model_histogram.shape
+
+    ### total counts per Phi bin should be preserved (rebin_phi only changes spatial pattern)
+    phi_original = np.sum(bkg_model_histogram[:],       axis=-1)  # sum over PsiChi
+    phi_rebin    = np.sum(bkg_model_histogram_rebin_smoothing[:], axis=-1)
+    assert np.allclose(phi_original, phi_rebin, rtol=1e-5)
+
+    ## Case 9: rebin_phi + l_cut
+    bkg_model_histogram_rebin_l_cut = instance.generate_bkg_model_histogram(
+        source_range, [background_region_1, background_region_2],
+        l_cut=3, rebin_phi=5)
+
+    ### shape should be unchanged
+    assert bkg_model_histogram_rebin_l_cut.shape == bkg_model_histogram.shape
+
+    ### total counts per Phi bin should be preserved
+    phi_rebin_l_cut = np.sum(bkg_model_histogram_rebin_l_cut[:], axis=-1)
+    assert np.allclose(phi_original, phi_rebin_l_cut, rtol=1e-5)


### PR DESCRIPTION
It adds spatial filtering (on the PsiChi plane) options to `generate_bkg_model_histogram` to mitigate Poisson fluctuations in the background model on the PsiChi plane.

Three new parameters are added to `generate_bkg_model_histogram`:
- `smoothing_fwhm`: applies Gaussian smoothing to the PsiChi map
- `l_cut`: applies a spherical harmonic low-pass filter, retaining only multipole moments up to `l_cut` (features on angular scales larger than ~180/l_cut degrees). Negative values introduced by the filter are clipped to zero.
- `rebin_phi`: merges adjacent Phi bins before applying the spatial filter, then restores the original binning. The spatial pattern of each Phi bin is replaced by the filtered template, while the total count of each original Phi bin is preserved.

Note: `smoothing_fwhm` and `l_cut` cannot be specified simultaneously and will raise a `ValueError`.